### PR TITLE
38 reverts to 6 months before prediction date for training data regardless of groundtruth

### DIFF
--- a/R/ff_run.R
+++ b/R/ff_run.R
@@ -119,6 +119,7 @@ ff_run <- function(shape = NULL, country = NULL, prediction_dates = NULL,
 
   if (is.null(trained_model)) {
     if (!hasvalue(train_dates)) {
+      ff_cat("No train dates were given though a training was wanted")
       # Extract the number of months from groundtruth_pattern (e.g., "6" from "groundtruth6m")
       months_back <- as.integer(gsub("\\D", "", groundtruth_pattern))
 
@@ -132,6 +133,8 @@ ff_run <- function(shape = NULL, country = NULL, prediction_dates = NULL,
         lubridate::ymd(min(prediction_dates)) %m-%
           months(months_back, abbreviate = FALSE)
       )
+      ff_cat("No train dates were given though a training was wanted, model will be trained on"
+             , train_dates ,color = "yellow")
     }
 
     if (max(lubridate::ymd(train_dates)) > min(lubridate::ymd(prediction_dates))) {
@@ -204,7 +207,8 @@ ff_run <- function(shape = NULL, country = NULL, prediction_dates = NULL,
 
     traindata <- do.call(ff_prep, ff_prep_params_combined)
     if (hasvalue(validation_dates)) {
-      ff_cat("adding validation matrix for dates", paste(validation_dates, collapse = ", "), "\n", color = "green", verbose = verbose)
+      ff_cat("adding validation matrix for dates", paste(validation_dates, collapse = ", "), "\n",
+             color = "green", verbose = verbose)
 
       ff_prep_params_combined["dates"] <- validation_dates
       ff_prep_params_combined["sample_size"] <- 1 / 3 * sample_size

--- a/R/ff_run.R
+++ b/R/ff_run.R
@@ -119,7 +119,19 @@ ff_run <- function(shape = NULL, country = NULL, prediction_dates = NULL,
 
   if (is.null(trained_model)) {
     if (!hasvalue(train_dates)) {
-      train_dates <- as.character(lubridate::ymd(min(prediction_dates)) %m-% months(6, abbreviate = FALSE))
+      # Extract the number of months from groundtruth_pattern (e.g., "6" from "groundtruth6m")
+      months_back <- as.integer(gsub("\\D", "", groundtruth_pattern))
+
+      # Fallback to 6 months if pattern is invalid or missing
+      if (is.na(months_back) || months_back <= 0) {
+        months_back <- 6
+        warning("Invalid or missing groundtruth_pattern. Defaulting to 6 months.")
+      }
+
+      train_dates <- as.character(
+        lubridate::ymd(min(prediction_dates)) %m-%
+          months(months_back, abbreviate = FALSE)
+      )
     }
 
     if (max(lubridate::ymd(train_dates)) > min(lubridate::ymd(prediction_dates))) {

--- a/R/ff_run.R
+++ b/R/ff_run.R
@@ -133,8 +133,10 @@ ff_run <- function(shape = NULL, country = NULL, prediction_dates = NULL,
         lubridate::ymd(min(prediction_dates)) %m-%
           months(months_back, abbreviate = FALSE)
       )
-      ff_cat("No train dates were given though a training was wanted, model will be trained on"
-             , train_dates ,color = "yellow")
+      ff_cat("No train dates were given though a training was wanted, model will be trained on",
+        train_dates,
+        color = "yellow"
+      )
     }
 
     if (max(lubridate::ymd(train_dates)) > min(lubridate::ymd(prediction_dates))) {
@@ -208,7 +210,8 @@ ff_run <- function(shape = NULL, country = NULL, prediction_dates = NULL,
     traindata <- do.call(ff_prep, ff_prep_params_combined)
     if (hasvalue(validation_dates)) {
       ff_cat("adding validation matrix for dates", paste(validation_dates, collapse = ", "), "\n",
-             color = "green", verbose = verbose)
+        color = "green", verbose = verbose
+      )
 
       ff_prep_params_combined["dates"] <- validation_dates
       ff_prep_params_combined["sample_size"] <- 1 / 3 * sample_size


### PR DESCRIPTION
<!--

after these changes the training date will be set for 1 month, based on the available groundtruth pattern.
### Related Issues

#38 
