### PR TITLE
using library(ForestForesight) will automatically call config_load()

### DIFF
--- a/R/config_load.R
+++ b/R/config_load.R
@@ -12,6 +12,7 @@ config_load <- function(config_file_path = "") {
 
   if (file.exists(config_file)) {
     load_variables(config_file)
+    message("Default config, env.yml loaded successfully.")
 
     # user_config_file is used by users to replace or supplement default configuration
     user_config_file <- here::here("config.yml")

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,3 +1,3 @@
 .onLoad <- function(libname, pkgname) {
-  config_load()  # Call the config_load function when the package is loaded
+  config_load() # Call the config_load function when the package is loaded
 }

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+  config_load()  # Call the config_load function when the package is loaded
+}


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Choose a meaningful title for this pull request.
- Please fill out all sections of this form. You can delete the placeholder comments.
- Pull Requests without clear information will take longer and may even be rejected.
- **Note:** Pull requests should be created from **[confirmed]** issues tracked in the issue management board.

-->

### Description
When a user/developer load ForestForesight library 
`library(ForestForesight)`
it will automatically call config_load()

However, if user/developer update their config.yml or env.yml, config_load has to be called again in order for the new values to be loaded. 
### Requirements

<!-- Does this PR require a specific requirement? -->

### Configurations

<!-- If applicable attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

#5 