### PR TITLE
86 ff sync does not give an error if the incorrect input for feature is given

### DIFF
--- a/R/ff_sync.R
+++ b/R/ff_sync.R
@@ -341,7 +341,7 @@ prediction_downloader <- function(ff_folder, country_codes, dates_to_check, buck
 #' @noRd
 sync_initialize_and_check <- function(ff_folder, date_start, date_end, features){
   if (!(casefold(features) %in%
-        c("Highest", "High", "Medium", "Low", "Everything","Small Model"))) {
+        c("highest", "high", "medium", "low", "everything","small model"))) {
     stop("incorrect feature option given. please choose between:
          Highest, High, Medium, Low, Everything, Small Model")
   }


### PR DESCRIPTION
the previous merge did not show an error but the unit tests turned out to be incorrect. fixed the bug.